### PR TITLE
Link statically against the runtime library

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, CMake
 class HelloConan(ConanFile):
     name = "Hello"
     version = "0.1"
-    license="MIT"
+    license = "MIT"
     settings = "os", "compiler", "build_type", "arch"
     url = "https://github.com/memsharded/conan-hello.git"
 
@@ -21,4 +21,8 @@ class HelloConan(ConanFile):
         self.copy("*.a", dst="lib", src="hello/lib")
 
     def package_info(self):
+        self.cpp_info.cxxflags = [
+            "-static-libgcc",
+            "-static-libstdc++"
+        ]
         self.cpp_info.libs = ["hello"]


### PR DESCRIPTION
If you follow this Conan documentation.

https://docs.conan.io/en/latest/systems_cross_building/cross_building.html#linux-to-windows

Then attempt to run the resulting executable on the target platform (Windows), you will encounter errors concerning the absence of the following DLL files.

- `libstdc++-6.dll`
- `libgcc_s_seh-1.dll`

Either the documentation should be updated to explain the prerequisites required to run this example on the target platform, or we should just statically link the runtime libraries and save anyone following the example documentation the confusion.